### PR TITLE
Write the script ID in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 [Doc](http://qiita.com/Arahabica/items/063877b0da439020d2c2)
 
-## Project key
+## Script ID (For New editor)
+
+`1M8DHQSWWGOM2RSRjDZmylHMl03nZHnliaVMGMk84m6jQ05ditPBTCSM8`
+
+## Project Key (For Legacy editor)
 
 `MDT2NQ9jkAGYJ-7ftp_A0v08CaFRWuzzx`


### PR DESCRIPTION
## Why

The IDE of Google Apps Script has been renewal.
The new IDE has been changed how to add a library, need the script ID instead of the project key.

> New editor
> https://developers.google.com/apps-script/guides/libraries#new-editor
> You **need the script ID** of the library you want to include. When you have access to the library, you can find the script ID on the Project Settings settings page.

> Legacy editor
> https://developers.google.com/apps-script/guides/libraries#legacy-editor
> You also need **the project key** of the library you are including. If you have access to the library, you can find the project key under File > Project Properties... Otherwise, you need to ask the author of the library to give you the project key.

The script ID can be checked with this URL.
https://script.google.com/macros/library/versions/d/1M8DHQSWWGOM2RSRjDZmylHMl03nZHnliaVMGMk84m6jQ05ditPBTCSM8

And I tried to input to the new IDE.

![ 2021-03-18 9 33 26](https://user-images.githubusercontent.com/14119304/111556051-03feae80-87cd-11eb-9191-4130d6d7d198.png)
## What

wrote a script ID of this library in README.

## How to check

N/A
